### PR TITLE
use correct tag

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -6,7 +6,7 @@ presubmits:
     context: aicoe-ci/prow/pre-commit
     spec:
       containers:
-        - image: quay.io/thoth-station/thoth-precommit-py38:v0.12.5
+        - image: quay.io/thoth-station/thoth-precommit-py38:v0.12.7
           command:
             - "pre-commit"
             - "run"


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

## Related Issues and Dependencies

```
[INFO] Initializing environment for git://github.com/Lucas-C/pre-commit-hooks.
[INFO] Initializing environment for git://github.com/pre-commit/pre-commit-hooks.
[INFO] Initializing environment for git://github.com/pycqa/pydocstyle.git.
[INFO] Initializing environment for https://github.com/pre-commit/pre-commit-hooks.
[INFO] Initializing environment for https://github.com/pre-commit/mirrors-mypy.
[INFO] Initializing environment for https://github.com/psf/black.
[ERROR] The hook `black` requires pre-commit version 2.9.2 but version 2.7.1 is installed.  Perhaps run `pip install --upgrade pre-commit`.
```
